### PR TITLE
NIP-13: enforce configurable proof of work

### DIFF
--- a/cagliostr.hxx
+++ b/cagliostr.hxx
@@ -57,6 +57,9 @@ void storage_context_init_postgresql(storage_context_t &);
 
 bool check_event(const event_t &);
 
+// NIP-13: count the number of leading zero bits in a hex-encoded event id.
+int count_leading_zero_bits(const std::string &);
+
 inline void to_json(nlohmann::json &j, const event_t &e) {
   j = nlohmann::json{
       {"id", e.id},           {"pubkey", e.pubkey},

--- a/main.cxx
+++ b/main.cxx
@@ -52,8 +52,8 @@ static auto nip11 = nlohmann::json{
      "2c7cc62a697ea3a7826521f3fd34f0cb273693cbe5e9310f35449f43622a5cdc"},
     {"contact", "mattn.jp@gmail.com"},
     {"supported_nips",
-     nlohmann::json::array({1, 2, 4, 9, 11, 12, 15, 16, 20, 22, 26, 28, 33, 40,
-                            42, 45, 50, 62, 67, 70})},
+     nlohmann::json::array({1, 2, 4, 9, 11, 12, 13, 15, 16, 20, 22, 26, 28, 33,
+                            40, 42, 45, 50, 62, 67, 70})},
     {"software", "https://github.com/mattn/cagliostr"},
     {"version", VERSION},
     {"limitation", nlohmann::json{{"max_message_length", 1024 * 1024 * 5},
@@ -63,7 +63,7 @@ static auto nip11 = nlohmann::json{
                                   {"max_subid_length", 100},
                                   {"max_event_tags", 100},
                                   {"max_content_length", 16384},
-                                  {"min_pow_difficulty", 30},
+                                  {"min_pow_difficulty", 0},
                                   {"auth_required", false},
                                   {"payment_required", false},
                                   {"restricted_writes", false}}},
@@ -561,6 +561,20 @@ static void do_relay_event(WebSocket *ws, const nlohmann::json &data) {
       return;
     }
 
+    // NIP-13: enforce proof of work when a minimum difficulty is required.
+    int min_pow = nip11["limitation"]["min_pow_difficulty"];
+    if (min_pow > 0) {
+      int pow = count_leading_zero_bits(ev.id);
+      if (pow < min_pow) {
+        const auto reply = nlohmann::json::array(
+            {"OK", ev.id, false,
+             "pow: difficulty " + std::to_string(pow) + " is less than " +
+                 std::to_string(min_pow)});
+        relay_send(ws, reply);
+        return;
+      }
+    }
+
     for (const auto &tag : ev.tags) {
       if (tag.size() == 1 && tag[0] == "-") {
         if (!check_auth_pubkey(ws, ev.pubkey)) {
@@ -1054,6 +1068,12 @@ int main(int argc, char *argv[]) {
         .help("comma-separated list of relay countries (ISO 3166-1)")
         .metavar("COUNTRIES")
         .nargs(1);
+    program.add_argument("-min-pow")
+        .default_value(static_cast<int>(std::stoi(env("MIN_POW_DIFFICULTY", "0"))))
+        .help("minimum proof of work difficulty required for events (NIP-13)")
+        .metavar("BITS")
+        .scan<'i', int>()
+        .nargs(1);
     program.add_argument("-port")
         .default_value(static_cast<short>(7447))
         .help("port number")
@@ -1104,6 +1124,8 @@ int main(int argc, char *argv[]) {
     }
     nip11["relay_countries"] = std::move(countries);
   }
+
+  nip11["limitation"]["min_pow_difficulty"] = program.get<int>("-min-pow");
 
   // Setup signal handler
   std::signal(SIGINT, signal_handler);

--- a/sign.cxx
+++ b/sign.cxx
@@ -123,6 +123,29 @@ static bool check_delegation(const event_t &ev,
                           delegation_digest);
 }
 
+int count_leading_zero_bits(const std::string &hex) {
+  int count = 0;
+  for (const auto c : hex) {
+    auto nibble = hex_value(c);
+    if (nibble < 0) {
+      break;
+    }
+    if (nibble == 0) {
+      count += 4;
+      continue;
+    }
+    if (nibble <= 1) {
+      count += 3;
+    } else if (nibble <= 3) {
+      count += 2;
+    } else if (nibble <= 7) {
+      count += 1;
+    }
+    break;
+  }
+  return count;
+}
+
 bool check_event(const event_t &ev) {
   nlohmann::json check = nlohmann::json::array({
       0,

--- a/test.cxx
+++ b/test.cxx
@@ -341,6 +341,17 @@ static void test_cagliostr_sign() {
   _ok(!check_event(ev), "check_event should be failed for invalid sig");
 }
 
+static void test_count_leading_zero_bits() {
+  _ok(count_leading_zero_bits("ffff") == 0, "no leading zero bits");
+  _ok(count_leading_zero_bits("7fff") == 1, "one leading zero bit");
+  _ok(count_leading_zero_bits("0fff") == 4, "one zero nibble");
+  _ok(count_leading_zero_bits("00ff") == 8, "two zero nibbles");
+  _ok(count_leading_zero_bits("002f") == 10, "two zero nibbles plus two bits");
+  _ok(count_leading_zero_bits("000000000e9d897a3aa5f...") == 36,
+      "leading zeros stop at first set bit");
+  _ok(count_leading_zero_bits("") == 0, "empty id has no leading zeros");
+}
+
 int main() {
   spdlog::set_level(spdlog::level::off);
 
@@ -352,6 +363,7 @@ int main() {
           test_delete_record_by_id_and_kind_and_ptag);
   subtest("test_delete_all_events_by_pubkey", test_delete_all_events_by_pubkey);
   subtest("test_cagliostr_sign", test_cagliostr_sign);
+  subtest("test_count_leading_zero_bits", test_count_leading_zero_bits);
   subtest("test_sql_injection_protection", test_sql_injection_protection);
   return done_testing();
 }


### PR DESCRIPTION
Enforce NIP-13 proof of work when a minimum difficulty is configured.

- add `count_leading_zero_bits` and reject events below `min_pow_difficulty`
- make the threshold configurable via `-min-pow` / `MIN_POW_DIFFICULTY` (default 0)
- advertise NIP-13 in `supported_nips`; the advertised difficulty now matches what is enforced
- add a unit test for `count_leading_zero_bits`