### PR TITLE
NIP-09: support deletion by addressable event coordinate

### DIFF
--- a/cagliostr.hxx
+++ b/cagliostr.hxx
@@ -79,6 +79,39 @@ inline void from_json(const nlohmann::json &j, event_t &e) {
   j.at("sig").get_to(e.sig);
 }
 
+// NIP-09: parse an addressable event coordinate ("kind:pubkey:dtag") from an
+// "a" tag value. Returns false when the value is malformed.
+inline bool parse_a_coordinate(const std::string &coordinate, int &kind,
+                               std::string &pubkey, std::string &dtag) {
+  auto first = coordinate.find(':');
+  if (first == std::string::npos) {
+    return false;
+  }
+  auto second = coordinate.find(':', first + 1);
+  if (second == std::string::npos) {
+    return false;
+  }
+  const auto kind_str = coordinate.substr(0, first);
+  if (kind_str.empty()) {
+    return false;
+  }
+  try {
+    size_t pos = 0;
+    kind = std::stoi(kind_str, &pos);
+    if (pos != kind_str.size()) {
+      return false;
+    }
+  } catch (const std::exception &) {
+    return false;
+  }
+  pubkey = coordinate.substr(first + 1, second - first - 1);
+  dtag = coordinate.substr(second + 1);
+  if (pubkey.empty()) {
+    return false;
+  }
+  return true;
+}
+
 inline std::string escape_like(const std::string &data) {
   std::string result;
   for (const auto c : data) {

--- a/main.cxx
+++ b/main.cxx
@@ -614,6 +614,19 @@ static void do_relay_event(WebSocket *ws, const nlohmann::json &data) {
               }
             }
           }
+        } else if (tag.size() >= 2 && tag[0] == "a") {
+          // NIP-09: delete addressable events referenced by coordinate.
+          int kind = 0;
+          std::string pubkey, dtag;
+          if (parse_a_coordinate(tag[1], kind, pubkey, dtag) &&
+              pubkey == ev.pubkey) {
+            std::vector<std::string> dtag_pair = {"d", dtag};
+            auto r = storage_ctx.delete_record_by_kind_and_pubkey_and_dtag(
+                kind, ev.pubkey, dtag_pair, ev.created_at + 1);
+            if (r < 0) {
+              delete_failed = true;
+            }
+          }
         }
       }
 

--- a/test.cxx
+++ b/test.cxx
@@ -352,6 +352,30 @@ static void test_count_leading_zero_bits() {
   _ok(count_leading_zero_bits("") == 0, "empty id has no leading zeros");
 }
 
+static void test_parse_a_coordinate() {
+  int kind = 0;
+  std::string pubkey, dtag;
+
+  _ok(parse_a_coordinate("30023:abcd:my-article", kind, pubkey, dtag),
+      "parse_a_coordinate accepts a valid coordinate");
+  _ok(kind == 30023, "parse_a_coordinate extracts kind");
+  _ok(pubkey == "abcd", "parse_a_coordinate extracts pubkey");
+  _ok(dtag == "my-article", "parse_a_coordinate extracts dtag");
+
+  _ok(parse_a_coordinate("30000:abcd:", kind, pubkey, dtag),
+      "parse_a_coordinate accepts an empty dtag");
+  _ok(dtag == "", "parse_a_coordinate keeps empty dtag");
+
+  _ok(!parse_a_coordinate("30023:abcd", kind, pubkey, dtag),
+      "parse_a_coordinate rejects a missing dtag separator");
+  _ok(!parse_a_coordinate("abc:abcd:x", kind, pubkey, dtag),
+      "parse_a_coordinate rejects a non-numeric kind");
+  _ok(!parse_a_coordinate("30023::x", kind, pubkey, dtag),
+      "parse_a_coordinate rejects an empty pubkey");
+  _ok(!parse_a_coordinate("", kind, pubkey, dtag),
+      "parse_a_coordinate rejects an empty value");
+}
+
 int main() {
   spdlog::set_level(spdlog::level::off);
 
@@ -364,6 +388,7 @@ int main() {
   subtest("test_delete_all_events_by_pubkey", test_delete_all_events_by_pubkey);
   subtest("test_cagliostr_sign", test_cagliostr_sign);
   subtest("test_count_leading_zero_bits", test_count_leading_zero_bits);
+  subtest("test_parse_a_coordinate", test_parse_a_coordinate);
   subtest("test_sql_injection_protection", test_sql_injection_protection);
   return done_testing();
 }


### PR DESCRIPTION
Handle `a` tags in kind 5 deletion requests so addressable/replaceable events (e.g. NIP-33) can be deleted, not only `e`-tagged events.

- parse `kind:pubkey:dtag` coordinates and delete matching events authored by the requester up to the deletion's `created_at`
- add a unit test for the coordinate parser