### PR TITLE
Rate limit events per IP and per pubkey

### DIFF
--- a/cagliostr.hxx
+++ b/cagliostr.hxx
@@ -6,6 +6,10 @@
 #include <malloc.h>
 #endif
 
+#include <ctime>
+#include <list>
+#include <unordered_map>
+
 #include <nlohmann/json.hpp>
 #include <optional>
 #include <spdlog/common.h>
@@ -125,6 +129,65 @@ inline bool created_at_within_limits(std::time_t created_at, std::time_t now,
   }
   return true;
 }
+
+// Fixed-window rate limiter keyed by an arbitrary string (an IP address or a
+// pubkey). State is held in an LRU cache bounded by max_keys so that a flood of
+// unique keys cannot grow memory without limit; the least-recently-used key,
+// whose window is also the most stale, is evicted first. A limit or window of 0
+// disables the limiter and allows everything.
+class rate_limiter_t {
+public:
+  void configure(int limit, std::time_t window,
+                 std::size_t max_keys = 100000) {
+    limit_ = limit;
+    window_ = window;
+    max_keys_ = max_keys;
+  }
+
+  bool enabled() const { return limit_ > 0 && window_ > 0; }
+
+  // Record a hit for the given key at time `now` and report whether it is
+  // within the limit. When disabled, everything is allowed.
+  bool allow(const std::string &key, std::time_t now) {
+    if (!enabled()) {
+      return true;
+    }
+    auto it = entries_.find(key);
+    if (it == entries_.end()) {
+      if (max_keys_ > 0 && entries_.size() >= max_keys_) {
+        entries_.erase(lru_.back());
+        lru_.pop_back();
+      }
+      lru_.push_front(key);
+      it = entries_.emplace(key, entry_t{lru_.begin(), now, 0}).first;
+    } else {
+      // Touch: move this key to the most-recently-used end.
+      lru_.splice(lru_.begin(), lru_, it->second.pos);
+    }
+    auto &e = it->second;
+    if (now - e.start >= window_) {
+      e.start = now;
+      e.count = 0;
+    }
+    e.count++;
+    return e.count <= limit_;
+  }
+
+  std::size_t size() const { return entries_.size(); }
+
+private:
+  struct entry_t {
+    std::list<std::string>::iterator pos;
+    std::time_t start;
+    int count;
+  };
+
+  int limit_{0};
+  std::time_t window_{0};
+  std::size_t max_keys_{0};
+  std::list<std::string> lru_;
+  std::unordered_map<std::string, entry_t> entries_;
+};
 
 inline std::string escape_like(const std::string &data) {
   std::string result;

--- a/main.cxx
+++ b/main.cxx
@@ -48,6 +48,12 @@ static std::string service_url;
 static std::time_t created_at_lower_limit = 0;
 static std::time_t created_at_upper_limit = 900;
 
+// Rate limiting: fixed-window counters that cap how many events a single IP
+// address or pubkey may submit within the configured window. Disabled (limit 0)
+// by default.
+static rate_limiter_t ip_rate_limiter;
+static rate_limiter_t pubkey_rate_limiter;
+
 static storage_context_t storage_ctx;
 
 static auto nip11 = nlohmann::json{
@@ -561,6 +567,17 @@ static void do_relay_event(WebSocket *ws, const nlohmann::json &data) {
       return;
     }
 
+    // Rate limit by source IP before the expensive signature check. The IP is
+    // attacker-controllable only via spoofing the upstream proxy, so it is safe
+    // to throttle on before verification.
+    if (ip_rate_limiter.enabled() &&
+        !ip_rate_limiter.allow(realIP(ws), std::time(nullptr))) {
+      const auto reply = nlohmann::json::array(
+          {"OK", ev.id, false, "rate-limited: too many events from your IP"});
+      relay_send(ws, reply);
+      return;
+    }
+
     // NIP-22: reject events whose created_at is outside the accepted window.
     if (!created_at_within_limits(ev.created_at, std::time(nullptr),
                                   created_at_lower_limit,
@@ -574,6 +591,16 @@ static void do_relay_event(WebSocket *ws, const nlohmann::json &data) {
 
     if (!check_event(ev)) {
       relay_notice(ws, ev.id, "error: invalid id or signature");
+      return;
+    }
+
+    // Rate limit by pubkey only after the signature is verified, so that a
+    // forged event cannot get another author's pubkey throttled.
+    if (pubkey_rate_limiter.enabled() &&
+        !pubkey_rate_limiter.allow(ev.pubkey, std::time(nullptr))) {
+      const auto reply = nlohmann::json::array(
+          {"OK", ev.id, false, "rate-limited: too many events from your key"});
+      relay_send(ws, reply);
       return;
     }
 
@@ -1127,6 +1154,26 @@ int main(int argc, char *argv[]) {
         .metavar("SECONDS")
         .scan<'i', int>()
         .nargs(1);
+    program.add_argument("-rate-limit-ip")
+        .default_value(static_cast<int>(std::stoi(env("RATE_LIMIT_IP", "0"))))
+        .help("max events per window from a single IP (0 disables)")
+        .metavar("COUNT")
+        .scan<'i', int>()
+        .nargs(1);
+    program.add_argument("-rate-limit-pubkey")
+        .default_value(
+            static_cast<int>(std::stoi(env("RATE_LIMIT_PUBKEY", "0"))))
+        .help("max events per window from a single pubkey (0 disables)")
+        .metavar("COUNT")
+        .scan<'i', int>()
+        .nargs(1);
+    program.add_argument("-rate-limit-window")
+        .default_value(
+            static_cast<int>(std::stoi(env("RATE_LIMIT_WINDOW", "60"))))
+        .help("rate limit window in seconds (shared by IP and pubkey limits)")
+        .metavar("SECONDS")
+        .scan<'i', int>()
+        .nargs(1);
     program.add_argument("-port")
         .default_value(static_cast<short>(7447))
         .help("port number")
@@ -1182,6 +1229,25 @@ int main(int argc, char *argv[]) {
 
   created_at_lower_limit = program.get<int>("-created-at-lower-limit");
   created_at_upper_limit = program.get<int>("-created-at-upper-limit");
+
+  {
+    int rate_limit_window = program.get<int>("-rate-limit-window");
+    int rate_limit_ip = program.get<int>("-rate-limit-ip");
+    int rate_limit_pubkey = program.get<int>("-rate-limit-pubkey");
+    ip_rate_limiter.configure(rate_limit_ip, rate_limit_window);
+    pubkey_rate_limiter.configure(rate_limit_pubkey, rate_limit_window);
+    // NIP-11: advertise the active rate limits so clients can pace themselves.
+    if (ip_rate_limiter.enabled() || pubkey_rate_limiter.enabled()) {
+      nip11["limitation"]["restricted_writes"] = true;
+      nip11["limitation"]["rate_limit_window"] = rate_limit_window;
+      if (ip_rate_limiter.enabled()) {
+        nip11["limitation"]["max_events_per_ip"] = rate_limit_ip;
+      }
+      if (pubkey_rate_limiter.enabled()) {
+        nip11["limitation"]["max_events_per_pubkey"] = rate_limit_pubkey;
+      }
+    }
+  }
 
   // Setup signal handler
   std::signal(SIGINT, signal_handler);

--- a/test.cxx
+++ b/test.cxx
@@ -397,6 +397,42 @@ static void test_created_at_within_limits() {
       "created_at_within_limits rejects beyond the lower limit");
 }
 
+static void test_rate_limiter() {
+  std::time_t now = 1700000000;
+
+  // Disabled limiter allows everything.
+  rate_limiter_t disabled;
+  _ok(disabled.allow("a", now), "disabled limiter allows the first hit");
+  for (int i = 0; i < 1000; i++) {
+    disabled.allow("a", now);
+  }
+  _ok(disabled.allow("a", now), "disabled limiter never throttles");
+
+  // Allow up to `limit` hits per window, reject the next.
+  rate_limiter_t rl;
+  rl.configure(3, 60);
+  _ok(rl.allow("a", now), "first hit within limit");
+  _ok(rl.allow("a", now), "second hit within limit");
+  _ok(rl.allow("a", now), "third hit within limit");
+  _ok(!rl.allow("a", now), "fourth hit exceeds the limit");
+
+  // A different key has its own independent counter.
+  _ok(rl.allow("b", now), "other key is tracked independently");
+
+  // The counter resets once the window elapses.
+  _ok(rl.allow("a", now + 60), "counter resets after the window");
+
+  // The LRU cache stays bounded by max_keys.
+  rate_limiter_t bounded;
+  bounded.configure(1, 60, 2);
+  bounded.allow("k1", now);
+  bounded.allow("k2", now);
+  bounded.allow("k3", now);
+  _ok(bounded.size() == 2, "LRU cache never exceeds max_keys");
+  // k1 was evicted, so it gets a fresh window.
+  _ok(bounded.allow("k1", now), "evicted key starts a fresh window");
+}
+
 int main() {
   spdlog::set_level(spdlog::level::off);
 
@@ -411,6 +447,7 @@ int main() {
   subtest("test_count_leading_zero_bits", test_count_leading_zero_bits);
   subtest("test_parse_a_coordinate", test_parse_a_coordinate);
   subtest("test_created_at_within_limits", test_created_at_within_limits);
+  subtest("test_rate_limiter", test_rate_limiter);
   subtest("test_sql_injection_protection", test_sql_injection_protection);
   return done_testing();
 }


### PR DESCRIPTION
Throttle repeated event submissions from the same source IP or pubkey. No NIP mandates rate limiting, but over-limit events are rejected with a NIP-01 `rate-limited:` reply and the limits are advertised via NIP-11.

- add `rate_limiter_t`: a fixed-window counter held in an LRU cache bounded by `max_keys` so a flood of unique keys cannot grow memory without limit
- limit per IP and per pubkey independently; exceeding either rejects the event
- enforce the IP limit before signature verification, the pubkey limit after `check_event` so a forged event cannot throttle another author's pubkey
- advertise `max_events_per_ip`/`max_events_per_pubkey`/`rate_limit_window` in the NIP-11 document when enabled
- add a unit test for the rate limiter

Configurable via CLI flags or environment variables (limits disabled by default):

| Flag | Env | Default | Meaning |
|---|---|---|---|
| `-rate-limit-ip` | `RATE_LIMIT_IP` | `0` | max events per window from one IP (0 disables) |
| `-rate-limit-pubkey` | `RATE_LIMIT_PUBKEY` | `0` | max events per window from one pubkey (0 disables) |
| `-rate-limit-window` | `RATE_LIMIT_WINDOW` | `60` | window in seconds (shared by both limits) |