### PR TITLE
NIP-26: fix delegation checks and reply to EVENT errors with OK

### DIFF
--- a/main.cxx
+++ b/main.cxx
@@ -183,9 +183,9 @@ static inline void relay_notice(WebSocket *ws, const std::string &msg) {
   relay_send(ws, data);
 }
 
-static inline void relay_notice(WebSocket *ws, const std::string &id,
-                                const std::string &msg) {
-  nlohmann::json data = {"NOTICE", id, msg};
+static inline void relay_ok(WebSocket *ws, const std::string &id, bool ok,
+                            const std::string &msg) {
+  nlohmann::json data = {"OK", id, ok, msg};
   relay_send(ws, data);
 }
 
@@ -361,7 +361,7 @@ static void do_relay_req(WebSocket *ws, const nlohmann::json &data) {
   }
   int max_subs = nip11["limitation"]["max_subscriptions"];
   if (sub_count >= max_subs) {
-    relay_notice(ws, sub, "error: too many subscriptions");
+    relay_closed(ws, sub, "error: too many subscriptions");
     return;
   }
 
@@ -372,7 +372,7 @@ static void do_relay_req(WebSocket *ws, const nlohmann::json &data) {
       continue;
     }
     if (filters.size() >= static_cast<size_t>(max_filters)) {
-      relay_notice(ws, sub, "error: too many filters");
+      relay_closed(ws, sub, "error: too many filters");
       return;
     }
     try {
@@ -387,9 +387,7 @@ static void do_relay_req(WebSocket *ws, const nlohmann::json &data) {
     }
   }
   if (filters.empty()) {
-    const auto reply =
-        nlohmann::json::array({"NOTICE", sub, "error: invalid filter"});
-    relay_send(ws, reply);
+    relay_closed(ws, sub, "error: invalid filter");
     return;
   }
 
@@ -435,9 +433,7 @@ static void do_relay_count(WebSocket *ws, const nlohmann::json &data) {
     }
   }
   if (filters.empty()) {
-    const auto reply =
-        nlohmann::json::array({"NOTICE", sub, "error: invalid filter"});
-    relay_send(ws, reply);
+    relay_closed(ws, sub, "error: invalid filter");
     return;
   }
 
@@ -553,11 +549,11 @@ static void do_relay_event(WebSocket *ws, const nlohmann::json &data) {
     int max_tags = nip11["limitation"]["max_event_tags"];
     int max_content = nip11["limitation"]["max_content_length"];
     if (ev.tags.size() > static_cast<size_t>(max_tags)) {
-      relay_notice(ws, ev.id, "error: too many tags");
+      relay_ok(ws, ev.id, false, "invalid: too many tags");
       return;
     }
     if (ev.content.size() > static_cast<size_t>(max_content)) {
-      relay_notice(ws, ev.id, "error: content too large");
+      relay_ok(ws, ev.id, false, "invalid: content too large");
       return;
     }
 
@@ -573,7 +569,8 @@ static void do_relay_event(WebSocket *ws, const nlohmann::json &data) {
     }
 
     if (!check_event(ev)) {
-      relay_notice(ws, ev.id, "error: invalid id or signature");
+      relay_ok(ws, ev.id, false,
+               "invalid: event id, signature or delegation is invalid");
       return;
     }
 
@@ -685,14 +682,14 @@ static void do_relay_event(WebSocket *ws, const nlohmann::json &data) {
         // propagation)
         if (storage_ctx.delete_all_events_by_pubkey(ev.pubkey, ev.created_at) <
             0) {
-          relay_notice(ws, "error: failed to vanish events");
+          relay_ok(ws, ev.id, false, "error: failed to vanish events");
           return;
         }
       }
 
       // Always store kind 62 event for propagation to other relays
       if (!storage_ctx.insert_record(ev)) {
-        relay_notice(ws, "error: duplicate event");
+        relay_ok(ws, ev.id, false, "duplicate: event already exists");
         return;
       }
 
@@ -720,7 +717,7 @@ static void do_relay_event(WebSocket *ws, const nlohmann::json &data) {
                  (10000 <= ev.kind && ev.kind < 20000)) {
         if (storage_ctx.delete_record_by_kind_and_pubkey(ev.kind, ev.pubkey,
                                                          ev.created_at) < 0) {
-          relay_notice(ws, "error: failed to replace event");
+          relay_ok(ws, ev.id, false, "error: failed to replace event");
           return;
         }
       } else if (30000 <= ev.kind && ev.kind < 40000) {
@@ -729,7 +726,7 @@ static void do_relay_event(WebSocket *ws, const nlohmann::json &data) {
           if (tag.size() >= 2 && tag[0] == "d") {
             if (storage_ctx.delete_record_by_kind_and_pubkey_and_dtag(
                     ev.kind, ev.pubkey, tag, ev.created_at) < 0) {
-              relay_notice(ws, "error: failed to replace event");
+              relay_ok(ws, ev.id, false, "error: failed to replace event");
               return;
             }
           }
@@ -737,7 +734,7 @@ static void do_relay_event(WebSocket *ws, const nlohmann::json &data) {
       }
 
       if (!storage_ctx.insert_record(ev)) {
-        relay_notice(ws, "error: duplicate event");
+        relay_ok(ws, ev.id, false, "duplicate: event already exists");
         return;
       }
     }
@@ -759,7 +756,7 @@ static void do_relay_auth(WebSocket *ws, const nlohmann::json &data) {
   try {
     const event_t ev = data[1];
     if (!check_event(ev)) {
-      relay_notice(ws, "error: invalid id or signature");
+      relay_ok(ws, ev.id, false, "invalid: event id or signature is invalid");
       return;
     }
 
@@ -906,12 +903,7 @@ static void ws_message_handler(WebSocket *ws, std::string_view message,
     std::string method = payload[0];
     if (method != "EVENT" && method != "REQ" && method != "COUNT" &&
         method != "CLOSE" && method != "AUTH") {
-      if (payload.size() >= 2 && payload[1].is_string()) {
-        std::string id = payload[1];
-        relay_notice(ws, id, "error: invalid request");
-      } else {
-        relay_notice(ws, "error: invalid request");
-      }
+      relay_notice(ws, "error: invalid request");
       return;
     }
 
@@ -928,13 +920,23 @@ static void ws_message_handler(WebSocket *ws, std::string_view message,
 
     if (method == "REQ") {
       if (payload.size() < 3) {
-        relay_notice(ws, payload[1], "error: invalid request");
+        if (payload[1].is_string()) {
+          relay_closed(ws, payload[1].get<std::string>(),
+                       "error: invalid request");
+        } else {
+          relay_notice(ws, "error: invalid request");
+        }
         return;
       }
       do_relay_req(ws, payload);
     } else if (method == "COUNT") {
       if (payload.size() < 3) {
-        relay_notice(ws, payload[1], "error: invalid request");
+        if (payload[1].is_string()) {
+          relay_closed(ws, payload[1].get<std::string>(),
+                       "error: invalid request");
+        } else {
+          relay_notice(ws, "error: invalid request");
+        }
         return;
       }
       do_relay_count(ws, payload);
@@ -944,8 +946,6 @@ static void ws_message_handler(WebSocket *ws, std::string_view message,
       do_relay_event(ws, payload);
     } else if (method == "AUTH") {
       do_relay_auth(ws, payload);
-    } else {
-      relay_notice(ws, payload[1], "error: invalid request");
     }
   } catch (std::exception &e) {
     console->warn("!! {}", e.what());

--- a/sign.cxx
+++ b/sign.cxx
@@ -76,32 +76,43 @@ static bool check_delegation(const event_t &ev,
                              const std::string &conditions,
                              const std::string &delegation_sig) {
   if (!conditions.empty()) {
+    // NIP-26: conditions are AND-combined, except that multiple conditions
+    // on the same field enumerate the permitted values (e.g. "kind=0&kind=1"
+    // permits kind 0 or 1).
+    bool has_kind_condition = false;
+    bool kind_matched = false;
     std::istringstream iss(conditions);
     std::string condition;
     while (std::getline(iss, condition, '&')) {
-      auto eq_pos = condition.find('=');
-      if (eq_pos == std::string::npos)
+      auto op_pos = condition.find_first_of("=<>");
+      if (op_pos == std::string::npos)
         continue;
 
-      auto key = condition.substr(0, eq_pos);
-      auto value = condition.substr(eq_pos + 1);
+      auto key = condition.substr(0, op_pos);
+      auto op = condition[op_pos];
+      auto value = condition.substr(op_pos + 1);
 
-      if (key == "kind") {
-        if (std::to_string(ev.kind) != value) {
+      if (key == "kind" && op == '=') {
+        has_kind_condition = true;
+        if (std::to_string(ev.kind) == value) {
+          kind_matched = true;
+        }
+      } else if (key == "created_at" && (op == '<' || op == '>')) {
+        long long timestamp = 0;
+        try {
+          timestamp = std::stoll(value);
+        } catch (const std::exception &) {
           return false;
         }
-      } else if (key == "created_at") {
-        auto op_pos = value.find_first_of("<>");
-        if (op_pos != std::string::npos) {
-          char op = value[op_pos];
-          auto timestamp = std::stoll(value.substr(op_pos + 1));
-          if (op == '<' && ev.created_at >= timestamp) {
-            return false;
-          } else if (op == '>' && ev.created_at <= timestamp) {
-            return false;
-          }
+        if (op == '<' && ev.created_at >= timestamp) {
+          return false;
+        } else if (op == '>' && ev.created_at <= timestamp) {
+          return false;
         }
       }
+    }
+    if (has_kind_condition && !kind_matched) {
+      return false;
     }
   }
 

--- a/test.cxx
+++ b/test.cxx
@@ -341,6 +341,37 @@ static void test_cagliostr_sign() {
   _ok(!check_event(ev), "check_event should be failed for invalid sig");
 }
 
+static void test_cagliostr_delegation() {
+  // NIP-26 delegated events. All fixtures are signed by the delegatee
+  // (477318cf) and carry a delegation tag from the delegator (8e0d3d3e)
+  // with conditions "kind=1&kind=6&kind=7&created_at>1674834236&created_at<1677426236".
+  event_t ev;
+
+  ev = string2event(
+      R"({"kind":1,"id":"3f2f27313552a0e3901ca925a48a3aefdab5f4361d69b00a08ce0d5636ad6b9a","pubkey":"477318cfb5427b9cfc66a9fa376150c1ddbc62115ae27cef72417eb959691396","created_at":1675000000,"tags":[["delegation","8e0d3d3eb2881ec137a11debe736a9086715a8c8beeeda615780064d68bc25dd","kind=1&kind=6&kind=7&created_at>1674834236&created_at<1677426236","b7557acbbfbe2f4d0ffe84ebf39f3e6ec94c97255a1800a2b73f529cb9c3ba769e3e197f60cfe85f29f183c7d270da4143c8b4da228657af7d34a75d6effde26"]],"content":"delegated hello","sig":"ae573acf0402ee62cd9cc8d9faff832882f91862a213684fc73d17a460a301fcc4e6ed95192f0fcbb8720a5237c46eba243a240c37c6030a2c1180aefd809a2c"})");
+  _ok(check_event(ev),
+      "delegated kind 1 should pass with multiple kind conditions");
+
+  ev = string2event(
+      R"({"kind":7,"id":"a3f355b299fedd533b3f4e59564a0331df6c9b3c202b0f2a021a0df39eb1188a","pubkey":"477318cfb5427b9cfc66a9fa376150c1ddbc62115ae27cef72417eb959691396","created_at":1675000000,"tags":[["delegation","8e0d3d3eb2881ec137a11debe736a9086715a8c8beeeda615780064d68bc25dd","kind=1&kind=6&kind=7&created_at>1674834236&created_at<1677426236","b7557acbbfbe2f4d0ffe84ebf39f3e6ec94c97255a1800a2b73f529cb9c3ba769e3e197f60cfe85f29f183c7d270da4143c8b4da228657af7d34a75d6effde26"]],"content":"delegated hello","sig":"8e52b98fda7e1c126cc9599979a3c080bde2f22ee5661d34fb9593d0ab527aa60310e39a635df7cb3ee5350615d96fff88c4b6e91f4fe55c546a0911a5bf4780"})");
+  _ok(check_event(ev),
+      "delegated kind 7 should pass with multiple kind conditions");
+
+  ev = string2event(
+      R"({"kind":4,"id":"089677e381ca48c98a4cf40e5e62a1f5de8553a28f2acdd222fcd074c740c142","pubkey":"477318cfb5427b9cfc66a9fa376150c1ddbc62115ae27cef72417eb959691396","created_at":1675000000,"tags":[["delegation","8e0d3d3eb2881ec137a11debe736a9086715a8c8beeeda615780064d68bc25dd","kind=1&kind=6&kind=7&created_at>1674834236&created_at<1677426236","b7557acbbfbe2f4d0ffe84ebf39f3e6ec94c97255a1800a2b73f529cb9c3ba769e3e197f60cfe85f29f183c7d270da4143c8b4da228657af7d34a75d6effde26"]],"content":"delegated hello","sig":"9ec3cdf0c16aed1201f2b212a2cd215090cd5c51a58b3bc971320e4bfaee1aad66693ec3dd7fce4c1ebd7423a35a1888e7f1831c262b1c10629e2fd0489406a9"})");
+  _ok(!check_event(ev), "delegated kind 4 should fail: kind not permitted");
+
+  ev = string2event(
+      R"({"kind":1,"id":"2db224dbdf035ac2a7e77085c2e84d7e182d79ca1b207bc8b0652e00cb2649a5","pubkey":"477318cfb5427b9cfc66a9fa376150c1ddbc62115ae27cef72417eb959691396","created_at":1677500000,"tags":[["delegation","8e0d3d3eb2881ec137a11debe736a9086715a8c8beeeda615780064d68bc25dd","kind=1&kind=6&kind=7&created_at>1674834236&created_at<1677426236","b7557acbbfbe2f4d0ffe84ebf39f3e6ec94c97255a1800a2b73f529cb9c3ba769e3e197f60cfe85f29f183c7d270da4143c8b4da228657af7d34a75d6effde26"]],"content":"delegated hello","sig":"44c09c8aa955f265526edf9c4a6ed63f7f503ccf046893e118c96bb96da0e5964adbc730d0610b43df3ece0172308f979975a62893d004b34321fde89dfeaa43"})");
+  _ok(!check_event(ev),
+      "delegated event should fail: created_at is past the expiration");
+
+  ev = string2event(
+      R"({"kind":1,"id":"77e03e4feca354da5980a3a9262910d2f5c8d15caf344e20c47c29e43905bcc5","pubkey":"477318cfb5427b9cfc66a9fa376150c1ddbc62115ae27cef72417eb959691396","created_at":1675000000,"tags":[["delegation","8e0d3d3eb2881ec137a11debe736a9086715a8c8beeeda615780064d68bc25dd","kind=1&kind=6&kind=7&created_at>1674834236&created_at<1677426236","11111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111"]],"content":"delegated hello","sig":"b7bf28cd563d94a4a04a1b834f04a201689d0e24b629df817571feb75a4df7433832e01b1874d2fd810fba3a461ee5cbf9aacee7f01cc137a3e07cf1b8f04fee"})");
+  _ok(!check_event(ev),
+      "delegated event should fail: delegation token is invalid");
+}
+
 static void test_count_leading_zero_bits() {
   _ok(count_leading_zero_bits("ffff") == 0, "no leading zero bits");
   _ok(count_leading_zero_bits("7fff") == 1, "one leading zero bit");
@@ -408,6 +439,7 @@ int main() {
           test_delete_record_by_id_and_kind_and_ptag);
   subtest("test_delete_all_events_by_pubkey", test_delete_all_events_by_pubkey);
   subtest("test_cagliostr_sign", test_cagliostr_sign);
+  subtest("test_cagliostr_delegation", test_cagliostr_delegation);
   subtest("test_count_leading_zero_bits", test_count_leading_zero_bits);
   subtest("test_parse_a_coordinate", test_parse_a_coordinate);
   subtest("test_created_at_within_limits", test_created_at_within_limits);


### PR DESCRIPTION
Publishing a NIP-26 delegated event to cagliostr failed with a NOTICE and the client then hung until its publish timeout.

The delegation check evaluated multiple `kind=` conditions as AND, so a delegation like `kind=1&kind=6&kind=7` rejected every event. Per NIP-26 they enumerate the permitted values, so any single match is now accepted. Conditions were also split on `=`, which never appears in `created_at>N` / `created_at<N`, so the time window was silently never enforced; the operator is now parsed from the condition itself, and expired events or malformed timestamps are rejected.

Rejected events were answered with a non-standard three-element `["NOTICE", id, msg]` instead of an OK envelope, so clients displayed the event id as the notice text and waited for an OK that never came. All EVENT rejections now reply `["OK", id, false, msg]` and subscription errors reply `["CLOSED", sub, msg]`.

Added `test_cagliostr_delegation` with fixed vectors generated via go-nostr using the NIP-26 example keys (multi-kind accepted, non-permitted kind, expired window, bogus token). All 12 subtests pass. Verified end-to-end against a local instance: a delegated post from algia returns OK immediately, and a non-permitted kind is rejected instantly instead of timing out.