### PR TITLE
NIP-42: fix AUTH bypass via challenge/relay tag counting

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,11 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "ja"
+reviews:
+  profile: "chill"
+  high_level_summary: true
+  poem: false
+  auto_review:
+    enabled: true
+    drafts: false
+chat:
+  auto_reply: true

--- a/main.cxx
+++ b/main.cxx
@@ -760,25 +760,44 @@ static void do_relay_auth(WebSocket *ws, const nlohmann::json &data) {
       return;
     }
 
-    auto cc = get_challenge(ws);
-    auto ok = 0;
+    // NIP-42: the AUTH event must be kind 22242.
+    if (ev.kind != 22242) {
+      relay_ok(ws, ev.id, false, "invalid: auth event kind must be 22242");
+      return;
+    }
+
+    // NIP-42: created_at must be close (within ~10 minutes) to the current
+    // time to prevent replay of a previously observed AUTH event.
+    const std::time_t now = std::time(nullptr);
+    if (std::llabs(static_cast<long long>(now) -
+                   static_cast<long long>(ev.created_at)) > 600) {
+      relay_ok(ws, ev.id, false,
+               "invalid: auth event created_at is out of range");
+      return;
+    }
+
+    // NIP-42: verify the challenge and relay tags independently. Counting a
+    // single total would let two "relay" tags satisfy the check without a
+    // matching challenge, allowing a replayed AUTH event to authenticate.
+    const auto cc = get_challenge(ws);
+    bool challenge_matched = false;
+    bool relay_matched = false;
     for (const auto &tag : ev.tags) {
       if (tag.size() < 2)
         continue;
       if (tag[0] == "challenge") {
-        if (tag[1] == cc)
-          ok++;
-      }
-      if (tag[0] == "relay") {
+        if (!cc.empty() && tag[1] == cc)
+          challenge_matched = true;
+      } else if (tag[0] == "relay") {
         auto s = tag[1];
         while (!s.empty() && s.back() == '/')
           s.pop_back();
         if (s == service_url)
-          ok++;
+          relay_matched = true;
       }
     }
 
-    if (ok == 2) {
+    if (challenge_matched && relay_matched) {
       set_auth_pubkey(ws, ev.pubkey);
       nlohmann::json reply = {"OK", ev.id, true, ""};
       relay_send(ws, reply);

--- a/main.cxx
+++ b/main.cxx
@@ -779,6 +779,12 @@ static void do_relay_auth(WebSocket *ws, const nlohmann::json &data) {
     // NIP-42: verify the challenge and relay tags independently. Counting a
     // single total would let two "relay" tags satisfy the check without a
     // matching challenge, allowing a replayed AUTH event to authenticate.
+    // Normalize the configured service URL the same way as the relay tag so a
+    // trailing slash on either side does not cause a spurious mismatch.
+    std::string expected_relay = service_url;
+    while (!expected_relay.empty() && expected_relay.back() == '/')
+      expected_relay.pop_back();
+
     const auto cc = get_challenge(ws);
     bool challenge_matched = false;
     bool relay_matched = false;
@@ -792,7 +798,7 @@ static void do_relay_auth(WebSocket *ws, const nlohmann::json &data) {
         auto s = tag[1];
         while (!s.empty() && s.back() == '/')
           s.pop_back();
-        if (s == service_url)
+        if (s == expected_relay)
           relay_matched = true;
       }
     }


### PR DESCRIPTION
do_relay_auth counted challenge-tag and relay-tag matches into a single total and accepted the event when the total reached 2, so an AUTH event carrying two `relay` tags authenticated without any matching challenge. This let a replayed AUTH event authenticate as its signer.

- Verify the challenge tag and relay tag independently, requiring both to match, instead of summing a single counter
- Reject the AUTH event unless its kind is 22242
- Reject the AUTH event when created_at is more than ~10 minutes from the current time, closing the replay path
- Do not treat a challenge tag as matching when the connection has no challenge stored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **セキュリティ**
  - リレー認証で、イベント種別・タイムスタンプ・チャレンジ・接続先をより厳格に検証し、不正な認証を受け入れにくくしました。

- **開発支援**
  - コードレビューの日本語表示とハイレベル要約を有効化しました。
  - 自動レビューや自動返信チャットの有効化により、レビュー運用がよりスムーズになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->