### PR TITLE
NIP-59: advertise gift wrap support in supported_nips

### DIFF
--- a/main.cxx
+++ b/main.cxx
@@ -58,7 +58,7 @@ static auto nip11 = nlohmann::json{
     {"contact", "mattn.jp@gmail.com"},
     {"supported_nips",
      nlohmann::json::array({1, 2, 4, 9, 11, 12, 13, 15, 16, 20, 22, 26, 28, 33,
-                            40, 42, 45, 50, 62, 67, 70})},
+                            40, 42, 45, 50, 59, 62, 67, 70})},
     {"software", "https://github.com/mattn/cagliostr"},
     {"version", VERSION},
     {"limitation", nlohmann::json{{"max_message_length", 1024 * 1024 * 5},


### PR DESCRIPTION
Add NIP-59 to the supported_nips list in the NIP-11 relay information document.

The relay-side requirements of NIP-59 are already satisfied: kind:1059 gift wrap events are stored as regular events, kind:21059 falls into the ephemeral range (20000-29999) and is broadcast without being stored, and the created_at lower bound check is disabled by default so the backdated timestamps used by gift wraps are accepted. This change only advertises that support to clients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * リレーの対応仕様一覧に NIP-59 を追加しました。
  * 接続先が NIP-59 対応であることを正しく確認できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->