### PR TITLE
NIP-66: advertise relay liveness monitoring support in supported_nips

### DIFF
--- a/main.cxx
+++ b/main.cxx
@@ -58,7 +58,7 @@ static auto nip11 = nlohmann::json{
     {"contact", "mattn.jp@gmail.com"},
     {"supported_nips",
      nlohmann::json::array({1, 2, 4, 9, 11, 12, 13, 15, 16, 17, 20, 22, 26, 28,
-                            33, 40, 42, 45, 50, 59, 62, 67, 70})},
+                            33, 40, 42, 45, 50, 59, 62, 66, 67, 70})},
     {"software", "https://github.com/mattn/cagliostr"},
     {"version", VERSION},
     {"limitation", nlohmann::json{{"max_message_length", 1024 * 1024 * 5},


### PR DESCRIPTION
Add NIP-66 to the supported_nips list in the NIP-11 relay information document.

NIP-66 is implemented by relay monitors rather than by relays themselves, so the only relay-side requirement is being able to store the events monitors publish: kind:30166 relay discovery events and kind:10166 monitor announcements. Both are handled by the existing addressable and replaceable event logic, which I verified locally by publishing two kind:30166 events with the same d tag and confirming only the newer one is served. This change just advertises that capability to clients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * リレー情報（NIP-11）で、NIP-66のサポートが表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->