### PR TITLE
Honor limit: 0 subscriptions

### DIFF
--- a/postgresql.cxx
+++ b/postgresql.cxx
@@ -241,7 +241,7 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
       os << filter.until;
       conditions.push_back("created_at <= " + os.str());
     }
-    if (filter.limit > 0 && filter.limit < limit) {
+    if (filter.limit >= 0 && filter.limit < limit) {
       limit = filter.limit;
     }
     if (!filter.search.empty()) {

--- a/sqlite3.cxx
+++ b/sqlite3.cxx
@@ -209,7 +209,7 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
       os << filter.until;
       conditions.push_back("created_at <= " + os.str());
     }
-    if (filter.limit > 0 && filter.limit < limit) {
+    if (filter.limit >= 0 && filter.limit < limit) {
       limit = filter.limit;
     }
     if (!filter.search.empty()) {

--- a/test.cxx
+++ b/test.cxx
@@ -228,6 +228,15 @@ static void test_send_records_filters() {
   _ok(has_more, "send_records reports more when events remain beyond the limit");
   replies.clear();
 
+  filter_t live_only;
+  live_only.limit = 0;
+  has_more = false;
+  _ok(storage_ctx.send_records(sender, "sub-live-only", {live_only}, false, &has_more),
+      "send_records accepts a zero limit");
+  _ok(replies.empty(), "limit zero returns no stored events");
+  _ok(has_more, "limit zero reports that stored events remain");
+  replies.clear();
+
   filter_t all_rows;
   all_rows.limit = 10;
   _ok(storage_ctx.send_records(sender, "sub-expiration", {all_rows}, false, nullptr),


### PR DESCRIPTION
Treat limit: 0 as a live-only subscription, return no stored events, and preserve the EOSE response. Add regression coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * `limit` に `0` を指定した場合、保存済みイベントを取得せず、追加イベントがあることを正しく示すようになりました。
  * PostgreSQL と SQLite の両方で、ゼロ件取得のフィルタが一貫して適用されます。


<!-- end of auto-generated comment: release notes by coderabbit.ai -->