### PR TITLE
Advertise NIP-78 support

### DIFF
--- a/main.cxx
+++ b/main.cxx
@@ -58,7 +58,7 @@ static auto nip11 = nlohmann::json{
     {"contact", "mattn.jp@gmail.com"},
     {"supported_nips",
      nlohmann::json::array({1, 4, 9, 11, 13, 17, 26, 40, 42, 45, 50, 59, 62,
-                            66, 70})},
+                            66, 70, 78})},
     {"software", "https://github.com/mattn/cagliostr"},
     {"version", VERSION},
     {"limitation", nlohmann::json{{"max_message_length", 1024 * 1024 * 5},


### PR DESCRIPTION
Advertise NIP-78 support in the relay information document. This aligns the advertised capabilities with https://github.com/nostr-protocol/nips/pull/2460.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * リレー情報ドキュメントで、サポート対象として公開される NIP の一覧に NIP-78 が追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->