### PR TITLE
Preserve SQLite event timestamps and content

### DIFF
--- a/sqlite3.cxx
+++ b/sqlite3.cxx
@@ -58,11 +58,12 @@ static std::optional<event_t> get_event_by_id(const std::string &id) {
   nlohmann::json ej;
   ej["id"] = (char *)sqlite3_column_text(stmt, 0);
   ej["pubkey"] = (char *)sqlite3_column_text(stmt, 1);
-  ej["created_at"] = sqlite3_column_int(stmt, 2);
+  ej["created_at"] = sqlite3_column_int64(stmt, 2);
   ej["kind"] = sqlite3_column_int(stmt, 3);
   const unsigned char *j = sqlite3_column_text(stmt, 4);
   ej["tags"] = nlohmann::json::parse(j);
-  ej["content"] = (char *)sqlite3_column_text(stmt, 5);
+  ej["content"] = std::string(reinterpret_cast<const char *>(sqlite3_column_text(stmt, 5)),
+                                    sqlite3_column_bytes(stmt, 5));
   ej["sig"] = (char *)sqlite3_column_text(stmt, 6);
   sqlite3_finalize(stmt);
   return ej;
@@ -82,7 +83,7 @@ static bool insert_record(const event_t &ev) {
   sqlite3_bind_text(stmt, 1, ev.id.data(), (int)ev.id.size(), SQLITE_TRANSIENT);
   sqlite3_bind_text(stmt, 2, ev.pubkey.data(), (int)ev.pubkey.size(),
                     SQLITE_TRANSIENT);
-  sqlite3_bind_int(stmt, 3, (int)ev.created_at);
+  sqlite3_bind_int64(stmt, 3, ev.created_at);
   sqlite3_bind_int(stmt, 4, ev.kind);
   sqlite3_bind_text(stmt, 5, s.data(), (int)s.size(), SQLITE_TRANSIENT);
   sqlite3_bind_text(stmt, 6, ev.content.data(), (int)ev.content.size(),
@@ -275,11 +276,12 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
         nlohmann::json ej;
         ej["id"] = (char *)sqlite3_column_text(stmt, 0);
         ej["pubkey"] = (char *)sqlite3_column_text(stmt, 1);
-        ej["created_at"] = sqlite3_column_int(stmt, 2);
+        ej["created_at"] = sqlite3_column_int64(stmt, 2);
         ej["kind"] = sqlite3_column_int(stmt, 3);
         const unsigned char *j = sqlite3_column_text(stmt, 4);
         ej["tags"] = nlohmann::json::parse(j);
-        ej["content"] = (char *)sqlite3_column_text(stmt, 5);
+        ej["content"] = std::string(reinterpret_cast<const char *>(sqlite3_column_text(stmt, 5)),
+                                    sqlite3_column_bytes(stmt, 5));
         ej["sig"] = (char *)sqlite3_column_text(stmt, 6);
 
         if (ej["tags"].is_array() && ej["tags"].size() > 0) {
@@ -343,7 +345,7 @@ static int delete_record_by_kind_and_pubkey(int kind, const std::string &pubkey,
   sqlite3_bind_int(stmt, 1, kind);
   sqlite3_bind_text(stmt, 2, pubkey.data(), (int)pubkey.size(),
                     SQLITE_TRANSIENT);
-  sqlite3_bind_int(stmt, 3, created_at);
+  sqlite3_bind_int64(stmt, 3, created_at);
 
   ret = sqlite3_step(stmt);
   if (ret != SQLITE_DONE) {
@@ -378,7 +380,7 @@ delete_record_by_kind_and_pubkey_and_dtag(int kind, const std::string &pubkey,
   sqlite3_bind_text(stmt, 2, pubkey.data(), (int)pubkey.size(),
                     SQLITE_TRANSIENT);
   sqlite3_bind_text(stmt, 3, s.data(), (int)s.size(), SQLITE_TRANSIENT);
-  sqlite3_bind_int(stmt, 4, created_at);
+  sqlite3_bind_int64(stmt, 4, created_at);
 
   std::vector<std::string> ids;
   while (true) {
@@ -499,7 +501,7 @@ static int delete_all_events_by_pubkey(const std::string &pubkey,
   }
   sqlite3_bind_text(stmt, 1, pubkey.data(), (int)pubkey.size(),
                     SQLITE_TRANSIENT);
-  sqlite3_bind_int(stmt, 2, created_at);
+  sqlite3_bind_int64(stmt, 2, created_at);
 
   ret = sqlite3_step(stmt);
   if (ret != SQLITE_DONE) {

--- a/test.cxx
+++ b/test.cxx
@@ -139,6 +139,39 @@ static void test_get_event_by_id() {
   storage_ctx.deinit();
 }
 
+static void test_sqlite_event_roundtrip() {
+  auto storage_ctx = init_test_storage();
+  auto ev = make_event("roundtrip-wide", "owner", 4102444800LL, 30023,
+                       {{"d", "wide"}}, std::string("before\0after", 12));
+  _ok(storage_ctx.insert_record(ev), "insert event with wide timestamp and NUL");
+  auto found = storage_ctx.get_event_by_id(ev.id);
+  _ok(found && found->created_at == ev.created_at, "lookup preserves 64-bit timestamp");
+  _ok(found && found->content == ev.content, "lookup preserves embedded NUL");
+  std::vector<nlohmann::json> replies;
+  filter_t filter;
+  filter.since = ev.created_at;
+  filter.until = ev.created_at;
+  _ok(storage_ctx.send_records([&](const nlohmann::json& r) { replies.push_back(r); },
+                               "roundtrip", {filter}, false, nullptr), "query wide timestamp");
+  _ok(replies.size() == 1 && replies[0][2] == nlohmann::json(ev),
+      "subscription preserves complete event");
+  _ok(storage_ctx.delete_record_by_kind_and_pubkey(ev.kind, ev.pubkey, ev.created_at) == 0,
+      "replacement preserves equal timestamp");
+  _ok(storage_ctx.delete_record_by_kind_and_pubkey(ev.kind, ev.pubkey, ev.created_at + 1) == 1,
+      "replacement uses 64-bit cutoff");
+  _ok(storage_ctx.insert_record(ev), "reinsert for address deletion");
+  _ok(storage_ctx.delete_record_by_kind_and_pubkey_and_dtag(ev.kind, ev.pubkey, {"d", "wide"}, ev.created_at) == 0,
+      "address deletion preserves equal timestamp");
+  _ok(storage_ctx.delete_record_by_kind_and_pubkey_and_dtag(ev.kind, ev.pubkey, {"d", "wide"}, ev.created_at + 1) == 1,
+      "address deletion uses 64-bit cutoff");
+  _ok(storage_ctx.insert_record(ev), "reinsert for vanish");
+  _ok(storage_ctx.delete_all_events_by_pubkey(ev.pubkey, ev.created_at - 1) == 0,
+      "vanish preserves newer event");
+  _ok(storage_ctx.delete_all_events_by_pubkey(ev.pubkey, ev.created_at) == 1,
+      "vanish uses 64-bit cutoff");
+  storage_ctx.deinit();
+}
+
 static void test_send_records_filters() {
   auto storage_ctx = init_test_storage();
   auto pubkey1 =
@@ -443,6 +476,7 @@ int main() {
   subtest("test_cagliostr_records", test_cagliostr_records);
   subtest("test_event_json_roundtrip", test_event_json_roundtrip);
   subtest("test_get_event_by_id", test_get_event_by_id);
+  subtest("test_sqlite_event_roundtrip", test_sqlite_event_roundtrip);
   subtest("test_send_records_filters", test_send_records_filters);
   subtest("test_delete_record_by_id_and_kind_and_ptag",
           test_delete_record_by_id_and_kind_and_ptag);


### PR DESCRIPTION
Preserve 64-bit timestamps and embedded NUL bytes in SQLite events, including time-based deletion cutoffs. Add regression coverage; local CTest passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * イベントの作成日時を64ビット整数で正確に保存・取得できるようにしました。
  * 本文に埋め込まれたNUL文字を含むコンテンツを、内容を損なわず処理できるようにしました。
  * 単一取得・一覧取得・検索・削除における境界時刻や大きなタイムスタンプの処理を改善しました。

* **テスト**
  * 64ビットの時刻値とNUL文字を含む本文の保存・取得・削除を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->