### PR TITLE
Match tag filters by exact key and value

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -14,6 +14,18 @@ env:
 jobs:
   build:
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:16-alpine
+        env:
+          POSTGRES_HOST_AUTH_METHOD: trust
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
 
     steps:
     - uses: actions/checkout@v3
@@ -39,3 +51,9 @@ jobs:
     - name: Test
       working-directory: ${{github.workspace}}/build
       run: ctest -C ${{env.BUILD_TYPE}}
+
+    - name: Test PostgreSQL
+      working-directory: ${{github.workspace}}/build
+      env:
+        CAGLIOSTR_TEST_POSTGRES_DSN: postgres://postgres@localhost:5432/postgres
+      run: ctest -C ${{env.BUILD_TYPE}} --output-on-failure

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ $ git submodule update --init --recursive
 $ cmake -B build && cmake --build build
 ```
 
+## Tests
+
+Run `ctest --test-dir build --output-on-failure` for SQLite tests.
+To test PostgreSQL, set `CAGLIOSTR_TEST_POSTGRES_DSN` to a disposable test
+database connection string and run the same command. The PostgreSQL tests
+truncate the `event` table before each storage test.
+
 ## License
 
 MIT

--- a/postgresql.cxx
+++ b/postgresql.cxx
@@ -213,23 +213,21 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
         conditions.push_back("kind in (" + condition + ")");
       }
     }
-    if (!filter.tags.empty()) {
-      std::vector<std::string> match;
-      for (const auto &tag : filter.tags) {
-        if (tag.size() < 2) {
-          continue;
-        }
-        for (decltype(tag.size()) i = 1; i < tag.size(); i++) {
-          params.append(tag[i]);
-        }
-        match.push_back(R"(tagvalues && ARRAY[)" +
-                        make_placeholders(tag.size() - 1, pno) + "]");
+    for (const auto &tag : filter.tags) {
+      if (tag.size() < 2) {
+        continue;
       }
-      if (match.size() == 1) {
-        conditions.push_back(match.front());
-      } else if (match.size() > 1) {
-        conditions.push_back("(" + join(match, " OR ") + ")");
+      params.append(tag[0]);
+      auto key = "$" + std::to_string(++pno);
+      for (size_t i = 1; i < tag.size(); ++i) {
+        params.append(tag[i]);
       }
+      auto values = make_placeholders(tag.size() - 1, pno);
+      // Keep the GIN-indexed value prefilter, then check the exact tag pair.
+      conditions.push_back("tagvalues && ARRAY[" + values + "]");
+      conditions.push_back(
+          "EXISTS (SELECT 1 FROM jsonb_array_elements(event.tags) AS tag "
+          "WHERE tag->>0 = " + key + " AND tag->>1 IN (" + values + "))");
     }
     if (filter.since != 0) {
       std::ostringstream os;

--- a/sqlite3.cxx
+++ b/sqlite3.cxx
@@ -180,25 +180,20 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
         conditions.push_back("kind in (" + condition + ")");
       }
     }
-    if (!filter.tags.empty()) {
-      std::vector<std::string> match;
-      for (const auto &tag : filter.tags) {
-        if (tag.size() < 2) {
-          continue;
-        }
-        auto first = tag[0];
-        for (decltype(tag.size()) i = 1; i < tag.size(); i++) {
-          nlohmann::json data = {first, tag[i]};
-          params.push_back({.t = PARAM_TYPE_STRING,
-                            .s = "%" + escape_like(data.dump()) + "%"});
-          match.push_back(R"(tags LIKE ? ESCAPE '\')");
-        }
+    for (const auto &tag : filter.tags) {
+      if (tag.size() < 2) {
+        continue;
       }
-      if (match.size() == 1) {
-        conditions.push_back(match.front());
-      } else if (match.size() > 1) {
-        conditions.push_back("(" + join(match, " OR ") + ")");
+      params.push_back({.t = PARAM_TYPE_STRING, .s = tag[0]});
+      std::vector<std::string> values;
+      for (size_t i = 1; i < tag.size(); ++i) {
+        values.push_back("?");
+        params.push_back({.t = PARAM_TYPE_STRING, .s = tag[i]});
       }
+      conditions.push_back(
+          "EXISTS (SELECT 1 FROM json_each(event.tags) AS tag "
+          "WHERE json_extract(tag.value, '$[0]') = ? "
+          "AND json_extract(tag.value, '$[1]') IN (" + join(values, ",") + "))");
     }
     if (filter.since != 0) {
       std::ostringstream os;

--- a/test.cxx
+++ b/test.cxx
@@ -11,6 +11,8 @@
 #include <spdlog/spdlog.h>
 
 #include <filesystem>
+#include <cstdlib>
+#include <pqxx/pqxx>
 #include <vector>
 
 static event_t string2event(const std::string& string) {
@@ -42,8 +44,17 @@ static event_t make_event(const std::string& id, const std::string& pubkey,
 }
 
 static storage_context_t init_test_storage(const char* path = "test.sqlite") {
-  std::filesystem::remove(path);
   storage_context_t storage_ctx;
+  if (const char* dsn = std::getenv("CAGLIOSTR_TEST_POSTGRES_DSN")) {
+    storage_context_init_postgresql(storage_ctx);
+    storage_ctx.init(dsn);
+    pqxx::connection conn(dsn);
+    pqxx::work txn(conn);
+    txn.exec("TRUNCATE event");
+    txn.commit();
+    return storage_ctx;
+  }
+  std::filesystem::remove(path);
   storage_context_init_sqlite3(storage_ctx);
   storage_ctx.init(path);
   return storage_ctx;
@@ -289,6 +300,36 @@ static void test_send_records_filters() {
   storage_ctx.deinit();
 }
 
+static void test_tag_filter_matching() {
+  auto storage_ctx = init_test_storage();
+  std::vector<event_t> events = {
+      make_event("tag-extra", "owner", 1700000000, 1, {{"t", "one", "relay"}, {"r", "two"}}, ""),
+      make_event("tag-one", "owner", 1700000001, 1, {{"t", "one"}}, ""),
+      make_event("tag-wrong-key", "owner", 1700000002, 1, {{"r", "one"}}, ""),
+      make_event("tag-wrong-case", "owner", 1700000003, 1, {{"t", "ONE"}}, ""),
+      make_event("tag-literal", "owner", 1700000004, 1, {{"t", "a_%\\b\""}}, ""),
+  };
+  for (const auto& ev : events) _ok(storage_ctx.insert_record(ev), "insert tag fixture");
+  auto query = [&](std::vector<std::vector<std::string>> tags, std::vector<std::string> expected) {
+    filter_t filter;
+    filter.tags = std::move(tags);
+    std::vector<std::string> ids;
+    _ok(storage_ctx.send_records([&](const nlohmann::json& r) { ids.push_back(r[2]["id"]); },
+                                 "tag-query", {filter}, false, nullptr), "query tag filter");
+    _ok(ids == expected, "tag filters match exact key/value pairs with AND across keys");
+    int count = -1;
+    _ok(storage_ctx.send_records([&](const nlohmann::json& r) { count = r[2]["count"]; },
+                                 "tag-count", {filter}, true, nullptr), "count tag filter");
+    _ok(count == static_cast<int>(expected.size()), "count uses the same tag conditions");
+  };
+  query({{"t", "one"}}, {"tag-one", "tag-extra"});
+  query({{"t", "one"}, {"r", "two"}}, {"tag-extra"});
+  query({{"t", "one", "ONE"}}, {"tag-wrong-case", "tag-one", "tag-extra"});
+  query({{"T", "one"}}, {});
+  query({{"t", "a_%\\b\""}}, {"tag-literal"});
+  storage_ctx.deinit();
+}
+
 static void test_delete_record_by_id_and_kind_and_ptag() {
   auto storage_ctx = init_test_storage();
   auto id = "event-ptag-1";
@@ -476,7 +517,9 @@ int main() {
   subtest("test_cagliostr_records", test_cagliostr_records);
   subtest("test_event_json_roundtrip", test_event_json_roundtrip);
   subtest("test_get_event_by_id", test_get_event_by_id);
-  subtest("test_sqlite_event_roundtrip", test_sqlite_event_roundtrip);
+  if (!std::getenv("CAGLIOSTR_TEST_POSTGRES_DSN"))
+    subtest("test_sqlite_event_roundtrip", test_sqlite_event_roundtrip);
+  subtest("test_tag_filter_matching", test_tag_filter_matching);
   subtest("test_send_records_filters", test_send_records_filters);
   subtest("test_delete_record_by_id_and_kind_and_ptag",
           test_delete_record_by_id_and_kind_and_ptag);


### PR DESCRIPTION
Match tag filters by exact key and first value, preserving extra tag fields and requiring every tag condition. Add SQLite and PostgreSQL regression tests and run both backends in CI.
