### PR TITLE
Match deletion tags by exact position

### DIFF
--- a/postgresql.cxx
+++ b/postgresql.cxx
@@ -350,97 +350,53 @@ static int delete_record_by_kind_and_pubkey(int kind, const std::string &pubkey,
   }
 }
 
-static int
-delete_record_by_kind_and_pubkey_and_dtag(int kind, const std::string &pubkey,
-                                          const std::vector<std::string> &tag,
-                                          std::time_t created_at) {
+static int delete_record_by_kind_and_pubkey_and_dtag(
+    int kind, const std::string &pubkey,
+    const std::vector<std::string> &tag, std::time_t created_at) {
+  if (tag.size() < 2) {
+    return 0;
+  }
   if (!ensure_connection()) {
     return -1;
   }
-  nlohmann::json data = nlohmann::json::array({tag});
-  std::vector<std::string> ids;
-
-  {
+  try {
     pqxx::work txn(*conn);
-    pqxx::result r = txn.exec(
-        R"(SELECT id FROM event WHERE kind = $1 AND pubkey = $2 AND tags @> $3::jsonb AND created_at < $4)",
-        pqxx::params{kind, pubkey, data.dump(), created_at});
+    auto result = txn.exec(
+        R"(DELETE FROM event WHERE kind = $1 AND pubkey = $2 AND created_at < $3
+           AND EXISTS (SELECT 1 FROM jsonb_array_elements(event.tags) AS tag
+                       WHERE tag->>0 = $4 AND tag->>1 = $5))",
+        pqxx::params{kind, pubkey, created_at, tag[0], tag[1]});
+    auto affected = result.affected_rows();
     txn.commit();
-
-    for (const auto &row : r) {
-      ids.push_back(row["id"].c_str());
-    }
+    return affected;
+  } catch (const std::exception &e) {
+    console->error("{}", e.what());
+    return -1;
   }
-  data.clear();
-
-  if (ids.empty()) {
-    return 0;
-  }
-
-  std::string condition;
-  pqxx::params params;
-  for (decltype(ids.size()) i = 0; i < ids.size(); i++) {
-    condition += "$" + std::to_string(i + 1) + ",";
-    params.append(ids[i]);
-  }
-  condition.pop_back();
-
-  int affected = 0;
-  {
-    pqxx::work txn(*conn);
-    pqxx::result r =
-        txn.exec("DELETE FROM event WHERE id IN (" + condition + ")", params);
-    affected = r.affected_rows();
-    txn.commit();
-  }
-
-  return affected;
 }
 
-static int
-delete_record_by_id_and_kind_and_ptag(const std::string &id, int kind,
-                                      const std::vector<std::string> &tag) {
+static int delete_record_by_id_and_kind_and_ptag(
+    const std::string &id, int kind, const std::vector<std::string> &tag) {
+  if (tag.size() < 2) {
+    return 0;
+  }
   if (!ensure_connection()) {
     return -1;
   }
-  nlohmann::json data = nlohmann::json::array({tag});
-  std::vector<std::string> ids;
-
-  {
+  try {
     pqxx::work txn(*conn);
-    pqxx::result r = txn.exec(
-        R"(SELECT id FROM event WHERE id = $1 AND kind = $2 AND tags @> $3::jsonb)",
-        pqxx::params{id, kind, data.dump()});
+    auto result = txn.exec(
+        R"(DELETE FROM event WHERE id = $1 AND kind = $2
+           AND EXISTS (SELECT 1 FROM jsonb_array_elements(event.tags) AS tag
+                       WHERE tag->>0 = $3 AND tag->>1 = $4))",
+        pqxx::params{id, kind, tag[0], tag[1]});
+    auto affected = result.affected_rows();
     txn.commit();
-
-    for (const auto &row : r) {
-      ids.push_back(row["id"].c_str());
-    }
+    return affected;
+  } catch (const std::exception &e) {
+    console->error("{}", e.what());
+    return -1;
   }
-  data.clear();
-
-  if (ids.empty()) {
-    return 0;
-  }
-
-  std::string condition;
-  pqxx::params params;
-  for (decltype(ids.size()) i = 0; i < ids.size(); i++) {
-    condition += "$" + std::to_string(i + 1) + ",";
-    params.append(ids[i]);
-  }
-  condition.pop_back();
-
-  int affected = 0;
-  {
-    pqxx::work txn(*conn);
-    pqxx::result r =
-        txn.exec("DELETE FROM event WHERE id IN (" + condition + ")", params);
-    affected = r.affected_rows();
-    txn.commit();
-  }
-
-  return affected;
 }
 
 static int delete_all_events_by_pubkey(const std::string &pubkey,

--- a/sqlite3.cxx
+++ b/sqlite3.cxx
@@ -353,134 +353,63 @@ static int delete_record_by_kind_and_pubkey(int kind, const std::string &pubkey,
   return sqlite3_changes(conn);
 }
 
-static int
-delete_record_by_kind_and_pubkey_and_dtag(int kind, const std::string &pubkey,
-                                          const std::vector<std::string> &tag,
-                                          std::time_t created_at) {
-  std::string sql =
-      R"(SELECT id FROM event WHERE kind = ? AND pubkey = ? AND tags LIKE ? ESCAPE '\' AND created_at < ?)";
-
-  sqlite3_stmt *stmt = nullptr;
-  auto ret =
-      sqlite3_prepare_v2(conn, sql.data(), (int)sql.size(), &stmt, nullptr);
-  if (ret != SQLITE_OK) {
-    console->error("{}", sqlite3_errmsg(conn));
-    return -1;
-  }
-
-  nlohmann::json data = tag;
-  auto s = "%" + escape_like(data.dump()) + "%";
-  data.clear();
-  sqlite3_bind_int(stmt, 1, kind);
-  sqlite3_bind_text(stmt, 2, pubkey.data(), (int)pubkey.size(),
-                    SQLITE_TRANSIENT);
-  sqlite3_bind_text(stmt, 3, s.data(), (int)s.size(), SQLITE_TRANSIENT);
-  sqlite3_bind_int64(stmt, 4, created_at);
-
-  std::vector<std::string> ids;
-  while (true) {
-    ret = sqlite3_step(stmt);
-    if (ret == SQLITE_DONE) {
-      break;
-    }
-    ids.push_back((char *)sqlite3_column_text(stmt, 0));
-  }
-  sqlite3_finalize(stmt);
-
-  if (ids.empty()) {
+static int delete_record_by_kind_and_pubkey_and_dtag(
+    int kind, const std::string &pubkey,
+    const std::vector<std::string> &tag, std::time_t created_at) {
+  if (tag.size() < 2) {
     return 0;
   }
-
-  std::string condition;
-  for (decltype(ids.size()) i = 0; i < ids.size(); i++) {
-    condition += "?,";
-  }
-  condition.pop_back();
-  sql = "DELETE FROM event WHERE id in (" + condition + ")";
-
-  stmt = nullptr;
-  ret = sqlite3_prepare_v2(conn, sql.data(), (int)sql.size(), &stmt, nullptr);
-  if (ret != SQLITE_OK) {
+  const auto sql =
+      R"(DELETE FROM event WHERE kind = ? AND pubkey = ? AND created_at < ?
+         AND EXISTS (SELECT 1 FROM json_each(event.tags) AS tag
+                     WHERE json_extract(tag.value, '$[0]') = ?
+                       AND json_extract(tag.value, '$[1]') = ?))";
+  sqlite3_stmt *stmt = nullptr;
+  if (sqlite3_prepare_v2(conn, sql, -1, &stmt, nullptr) != SQLITE_OK) {
     console->error("{}", sqlite3_errmsg(conn));
     return -1;
   }
-  for (decltype(ids.size()) i = 0; i < ids.size(); i++) {
-    sqlite3_bind_text(stmt, i + 1, ids[i].data(), (int)ids[i].size(),
-                      SQLITE_TRANSIENT);
-  }
-
-  ret = sqlite3_step(stmt);
+  sqlite3_bind_int(stmt, 1, kind);
+  sqlite3_bind_text(stmt, 2, pubkey.data(), (int)pubkey.size(), SQLITE_TRANSIENT);
+  sqlite3_bind_int64(stmt, 3, created_at);
+  sqlite3_bind_text(stmt, 4, tag[0].data(), (int)tag[0].size(), SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 5, tag[1].data(), (int)tag[1].size(), SQLITE_TRANSIENT);
+  auto ret = sqlite3_step(stmt);
   if (ret != SQLITE_DONE) {
     console->error("{}", sqlite3_errmsg(conn));
     sqlite3_finalize(stmt);
     return -1;
   }
   sqlite3_finalize(stmt);
-
   return sqlite3_changes(conn);
 }
 
-static int
-delete_record_by_id_and_kind_and_ptag(const std::string &id, int kind,
-                                      const std::vector<std::string> &tag) {
-  std::string sql =
-      R"(SELECT id FROM event WHERE id = ? AND kind = ? AND tags LIKE ? ESCAPE '\')";
-
-  sqlite3_stmt *stmt = nullptr;
-  auto ret =
-      sqlite3_prepare_v2(conn, sql.data(), (int)sql.size(), &stmt, nullptr);
-  if (ret != SQLITE_OK) {
-    console->error("{}", sqlite3_errmsg(conn));
-    return -1;
-  }
-
-  nlohmann::json data = tag;
-  auto s = "%" + escape_like(data.dump()) + "%";
-  data.clear();
-  sqlite3_bind_text(stmt, 1, id.data(), (int)id.size(), SQLITE_TRANSIENT);
-  sqlite3_bind_int(stmt, 2, kind);
-  sqlite3_bind_text(stmt, 3, s.data(), (int)s.size(), SQLITE_TRANSIENT);
-
-  std::vector<std::string> ids;
-  while (true) {
-    ret = sqlite3_step(stmt);
-    if (ret == SQLITE_DONE) {
-      break;
-    }
-    ids.push_back((char *)sqlite3_column_text(stmt, 0));
-  }
-  sqlite3_finalize(stmt);
-
-  if (ids.empty()) {
+static int delete_record_by_id_and_kind_and_ptag(
+    const std::string &id, int kind, const std::vector<std::string> &tag) {
+  if (tag.size() < 2) {
     return 0;
   }
-
-  std::string condition;
-  for (decltype(ids.size()) i = 0; i < ids.size(); i++) {
-    condition += "?,";
-  }
-  condition.pop_back();
-  sql = "DELETE FROM event WHERE id in (" + condition + ")";
-
-  stmt = nullptr;
-  ret = sqlite3_prepare_v2(conn, sql.data(), (int)sql.size(), &stmt, nullptr);
-  if (ret != SQLITE_OK) {
+  const auto sql =
+      R"(DELETE FROM event WHERE id = ? AND kind = ?
+         AND EXISTS (SELECT 1 FROM json_each(event.tags) AS tag
+                     WHERE json_extract(tag.value, '$[0]') = ?
+                       AND json_extract(tag.value, '$[1]') = ?))";
+  sqlite3_stmt *stmt = nullptr;
+  if (sqlite3_prepare_v2(conn, sql, -1, &stmt, nullptr) != SQLITE_OK) {
     console->error("{}", sqlite3_errmsg(conn));
     return -1;
   }
-  for (decltype(ids.size()) i = 0; i < ids.size(); i++) {
-    sqlite3_bind_text(stmt, i + 1, ids[i].data(), (int)ids[i].size(),
-                      SQLITE_TRANSIENT);
-  }
-
-  ret = sqlite3_step(stmt);
+  sqlite3_bind_text(stmt, 1, id.data(), (int)id.size(), SQLITE_TRANSIENT);
+  sqlite3_bind_int(stmt, 2, kind);
+  sqlite3_bind_text(stmt, 3, tag[0].data(), (int)tag[0].size(), SQLITE_TRANSIENT);
+  sqlite3_bind_text(stmt, 4, tag[1].data(), (int)tag[1].size(), SQLITE_TRANSIENT);
+  auto ret = sqlite3_step(stmt);
   if (ret != SQLITE_DONE) {
     console->error("{}", sqlite3_errmsg(conn));
     sqlite3_finalize(stmt);
     return -1;
   }
   sqlite3_finalize(stmt);
-
   return sqlite3_changes(conn);
 }
 

--- a/test.cxx
+++ b/test.cxx
@@ -361,6 +361,36 @@ static void test_delete_record_by_id_and_kind_and_ptag() {
   storage_ctx.deinit();
 }
 
+static void test_deletion_tag_matching() {
+  auto storage_ctx = init_test_storage();
+  std::vector<std::vector<std::string>> variants = {
+      {"p", "recipient", "relay"}, {"p", "other", "recipient"},
+      {"recipient", "p"}, {"p", "RECIPIENT"}, {"P", "recipient"}
+  };
+  for (size_t i = 0; i < variants.size(); ++i) {
+    auto ev = make_event("delete-tag-" + std::to_string(i), "owner", 1700000000,
+                         1059, {variants[i]}, "");
+    _ok(storage_ctx.insert_record(ev), "insert gift wrap tag fixture");
+    _ok(storage_ctx.delete_record_by_id_and_kind_and_ptag(ev.id, 1059, {"p", "recipient"}) == (i == 0 ? 1 : 0),
+        "gift wrap deletion checks recipient in the second tag position");
+  }
+  auto target = make_event("delete-address-extra", "owner", 1700000000, 30023,
+                           {{"d", "article", "metadata"}}, "");
+  auto other = make_event("delete-address-other", "owner", 1700000000, 30023,
+                          {{"d", "other", "article"}}, "");
+  auto upper = make_event("delete-address-upper", "owner", 1700000000, 30023,
+                          {{"d", "ARTICLE"}}, "");
+  _ok(storage_ctx.insert_record(target), "insert address with extra tag field");
+  _ok(storage_ctx.insert_record(other), "insert address with value in metadata");
+  _ok(storage_ctx.insert_record(upper), "insert case-distinct address");
+  _ok(storage_ctx.delete_record_by_kind_and_pubkey_and_dtag(30023, "owner", {"d", "article"}, 1700000001) == 1,
+      "address deletion matches exact d tag value");
+  _ok(!storage_ctx.get_event_by_id(target.id), "matching address deleted");
+  _ok(storage_ctx.get_event_by_id(other.id).has_value(), "metadata does not identify an address");
+  _ok(storage_ctx.get_event_by_id(upper.id).has_value(), "address matching is case-sensitive");
+  storage_ctx.deinit();
+}
+
 static void test_delete_all_events_by_pubkey() {
   auto storage_ctx = init_test_storage();
   auto pubkey =
@@ -523,6 +553,7 @@ int main() {
   subtest("test_send_records_filters", test_send_records_filters);
   subtest("test_delete_record_by_id_and_kind_and_ptag",
           test_delete_record_by_id_and_kind_and_ptag);
+  subtest("test_deletion_tag_matching", test_deletion_tag_matching);
   subtest("test_delete_all_events_by_pubkey", test_delete_all_events_by_pubkey);
   subtest("test_cagliostr_sign", test_cagliostr_sign);
   subtest("test_cagliostr_delegation", test_cagliostr_delegation);


### PR DESCRIPTION
Match deletion targets by exact tag key and value so metadata, reordered elements, and case differences cannot select unrelated events. Use a single DELETE and add regression tests for both databases.
