### PR TITLE
Correct stored filter results and counts

### DIFF
--- a/postgresql.cxx
+++ b/postgresql.cxx
@@ -6,6 +6,7 @@
 #include <nlohmann/json.hpp>
 #include <pqxx/pqxx>
 #include <sstream>
+#include <unordered_set>
 #include <string>
 #include <vector>
 
@@ -154,7 +155,11 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
   if (!ensure_connection()) {
     return false;
   }
-  auto count = 0;
+  int64_t count = 0;
+  std::unordered_set<std::string> sent_ids;
+  std::vector<std::string> count_conditions;
+  pqxx::params params;
+  int pno = 0;
   if (has_more != nullptr) {
     *has_more = false;
   }
@@ -168,9 +173,11 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
     }
 
     auto limit = 500;
-    pqxx::params params;
+    if (!do_count) {
+      params = pqxx::params{};
+      pno = 0;
+    }
     std::vector<std::string> conditions;
-    int pno = 0;
     if (!filter.ids.empty()) {
       if (filter.ids.size() == 1) {
         conditions.push_back("id = $" + std::to_string(++pno));
@@ -257,13 +264,19 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
                              R"( ESCAPE '\')");
       }
     }
-    if (!conditions.empty()) {
+    if (do_count) {
+      count_conditions.push_back(conditions.empty() ? "1=1" : join(conditions, " AND "));
+      if (count_conditions.size() != filters.size()) {
+        continue;
+      }
+      sql = "SELECT COUNT(*) FROM event WHERE (" + join(count_conditions, ") OR (") + ")";
+    } else if (!conditions.empty()) {
       sql += " WHERE " + join(conditions, " AND ");
     }
     if (!do_count) {
       // Fetch one extra row so we can tell whether more matching events exist
       // beyond the requested limit (NIP-67 EOSE completeness hint).
-      sql += " ORDER BY created_at DESC LIMIT " + std::to_string(limit + 1);
+      sql += " ORDER BY created_at DESC, id ASC LIMIT " + std::to_string(limit + 1);
     }
 
     pqxx::work txn(*conn);
@@ -271,7 +284,7 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
     txn.commit();
 
     if (do_count) {
-      count += r.one_field().as<int>();
+      count += r.one_field().as<int64_t>();
     } else {
       auto fetched = 0;
       for (const auto &row : r) {
@@ -301,7 +314,9 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
         }
 
         nlohmann::json reply = {"EVENT", sub, ej};
-        sender(reply);
+        if (sent_ids.insert(ej["id"].get<std::string>()).second) {
+          sender(reply);
+        }
       }
     }
   }

--- a/sqlite3.cxx
+++ b/sqlite3.cxx
@@ -3,6 +3,7 @@
 #include <ctime>
 #include <iostream>
 #include <sstream>
+#include <unordered_set>
 
 #include <sqlite3.h>
 
@@ -122,7 +123,10 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
                          const std::string &sub,
                          const std::vector<filter_t> &filters, bool do_count,
                          bool *has_more) {
-  auto count = 0;
+  int64_t count = 0;
+  std::unordered_set<std::string> sent_ids;
+  std::vector<std::string> count_conditions;
+  std::vector<param_t> params;
   if (has_more != nullptr) {
     *has_more = false;
   }
@@ -136,7 +140,9 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
     }
 
     auto limit = 500;
-    std::vector<param_t> params;
+    if (!do_count) {
+      params.clear();
+    }
     std::vector<std::string> conditions;
     if (!filter.ids.empty()) {
       if (filter.ids.size() == 1) {
@@ -209,15 +215,25 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
       limit = filter.limit;
     }
     if (!filter.search.empty()) {
-      params.push_back({.t = PARAM_TYPE_STRING,
-                        .s = "%" + escape_like(filter.search) + "%"});
-      conditions.push_back(R"(content LIKE ? ESCAPE '\')");
+      std::istringstream iss(filter.search);
+      std::string term;
+      while (iss >> term) {
+        params.push_back({.t = PARAM_TYPE_STRING,
+                          .s = "%" + escape_like(term) + "%"});
+        conditions.push_back(R"(content LIKE ? ESCAPE '\')");
+      }
     }
-    if (!conditions.empty()) {
+    if (do_count) {
+      count_conditions.push_back(conditions.empty() ? "1=1" : join(conditions, " AND "));
+      if (count_conditions.size() != filters.size()) {
+        continue;
+      }
+      sql = "SELECT COUNT(*) FROM event WHERE (" + join(count_conditions, ") OR (") + ")";
+    } else if (!conditions.empty()) {
       sql += " WHERE " + join(conditions, " AND ");
     }
     if (!do_count) {
-      sql += " ORDER BY created_at DESC LIMIT ?";
+      sql += " ORDER BY created_at DESC, id ASC LIMIT ?";
     }
 
     sqlite3_stmt *stmt = nullptr;
@@ -247,12 +263,12 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
     }
     if (do_count) {
       ret = sqlite3_step(stmt);
-      if (ret == SQLITE_DONE) {
+      if (ret != SQLITE_ROW) {
         console->error("{}", sqlite3_errmsg(conn));
         sqlite3_finalize(stmt);
         return false;
       }
-      count += sqlite3_column_int(stmt, 0);
+      count += sqlite3_column_int64(stmt, 0);
       sqlite3_finalize(stmt);
     } else {
       auto fetched = 0;
@@ -260,6 +276,11 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
         ret = sqlite3_step(stmt);
         if (ret == SQLITE_DONE) {
           break;
+        }
+        if (ret != SQLITE_ROW) {
+          console->error("{}", sqlite3_errmsg(conn));
+          sqlite3_finalize(stmt);
+          return false;
         }
         if (++fetched > limit) {
           // The extra row proves more matching events remain on the relay.
@@ -288,7 +309,9 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
         }
 
         nlohmann::json reply = {"EVENT", sub, ej};
-        sender(reply);
+        if (sent_ids.insert(ej["id"].get<std::string>()).second) {
+          sender(reply);
+        }
       }
       sqlite3_finalize(stmt);
     }

--- a/test.cxx
+++ b/test.cxx
@@ -339,6 +339,41 @@ static void test_send_records_filters() {
   storage_ctx.deinit();
 }
 
+static void test_overlapping_filters() {
+  auto storage_ctx = init_test_storage();
+  auto second = make_event("query-b", "owner", 1700000000, 1, {}, "unrelated");
+  auto first = make_event("query-a", "owner", 1700000000, 1, {}, "beta between ALPHA");
+  _ok(storage_ctx.insert_record(second), "insert higher id first");
+  _ok(storage_ctx.insert_record(first), "insert lower id second");
+  std::vector<std::string> ids;
+  auto sender = [&](const nlohmann::json& r) { ids.push_back(r[2]["id"]); };
+  filter_t all;
+  _ok(storage_ctx.send_records(sender, "query", {all, all}, false, nullptr), "query overlapping filters");
+  _ok(ids == std::vector<std::string>({first.id, second.id}), "emit each event once in timestamp/id order");
+  filter_t by_id;
+  by_id.ids = {first.id};
+  by_id.limit = 0;
+  int count = -1;
+  _ok(storage_ctx.send_records([&](const nlohmann::json& r) { count = r[2]["count"]; },
+                               "count", {by_id, all}, true, nullptr), "count overlapping filters");
+  _ok(count == 2, "count is a union and ignores filter limits");
+  filter_t tagged;
+  tagged.tags = {{"t", "missing"}};
+  _ok(storage_ctx.send_records([&](const nlohmann::json& r) { count = r[2]["count"]; },
+                               "count", {tagged, by_id}, true, nullptr), "count distinct parameterized filters");
+  _ok(count == 1, "each filter retains its own parameter bindings");
+  by_id.ids = {"absent"};
+  _ok(storage_ctx.send_records([&](const nlohmann::json& r) { count = r[2]["count"]; },
+                               "count", {by_id, by_id}, true, nullptr), "count empty filters");
+  _ok(count == 0, "count empty union");
+  filter_t search;
+  search.search = "alpha beta";
+  ids.clear();
+  _ok(storage_ctx.send_records(sender, "search", {search}, false, nullptr), "query multiple search words");
+  _ok(ids == std::vector<std::string>({first.id}), "search words match independently like live delivery");
+  storage_ctx.deinit();
+}
+
 static void test_tag_filter_matching() {
   auto storage_ctx = init_test_storage();
   std::vector<event_t> events = {
@@ -601,6 +636,7 @@ int main() {
   subtest("test_get_event_by_id", test_get_event_by_id);
   if (!std::getenv("CAGLIOSTR_TEST_POSTGRES_DSN"))
     subtest("test_sqlite_event_roundtrip", test_sqlite_event_roundtrip);
+  subtest("test_overlapping_filters", test_overlapping_filters);
   subtest("test_tag_filter_matching", test_tag_filter_matching);
   subtest("test_send_records_filters", test_send_records_filters);
   subtest("test_delete_record_by_id_and_kind_and_ptag",


### PR DESCRIPTION
Deduplicate stored event replies and OR filters together for COUNT. Order timestamp ties by ID and align SQLite multiword search with live matching; add regression coverage for both databases.
