### PR TITLE
Reject expired event publications

### DIFF
--- a/cagliostr.hxx
+++ b/cagliostr.hxx
@@ -2,6 +2,7 @@
 #define _CAGLIOSTR_H_
 
 #include <string>
+#include <charconv>
 #if defined(__GLIBC__)
 #include <malloc.h>
 #endif
@@ -124,6 +125,22 @@ inline bool created_at_within_limits(std::time_t created_at, std::time_t now,
     return false;
   }
   return true;
+}
+
+inline bool has_expired_tags(const std::vector<std::vector<std::string>> &tags,
+                             std::time_t now) {
+  for (const auto &tag : tags) {
+    if (tag.size() >= 2 && tag[0] == "expiration") {
+      std::time_t expiration = 0;
+      const auto *first = tag[1].data();
+      const auto *last = first + tag[1].size();
+      auto [ptr, ec] = std::from_chars(first, last, expiration);
+      if (ec == std::errc() && ptr == last && expiration <= now) {
+        return true;
+      }
+    }
+  }
+  return false;
 }
 
 inline std::string escape_like(const std::string &data) {

--- a/main.cxx
+++ b/main.cxx
@@ -599,6 +599,14 @@ static void do_relay_event(WebSocket *ws, const nlohmann::json &data) {
       return;
     }
 
+    // NIP-40: expired publications must not be stored or broadcast. Ephemeral
+    // events are exempt from expiration handling.
+    if (!(20000 <= ev.kind && ev.kind < 30000) &&
+        has_expired_tags(ev.tags, std::time(nullptr))) {
+      relay_ok(ws, ev.id, false, "invalid: event has expired");
+      return;
+    }
+
     // NIP-13: enforce proof of work when a minimum difficulty is required.
     int min_pow = nip11["limitation"]["min_pow_difficulty"];
     if (min_pow > 0) {

--- a/postgresql.cxx
+++ b/postgresql.cxx
@@ -119,22 +119,6 @@ static bool insert_record(const event_t &ev) {
   }
 }
 
-static bool is_expired(std::vector<std::vector<std::string>> &tags) {
-  time_t now = time(nullptr);
-  for (const auto &tag : tags) {
-    if (tag.size() == 2 && tag[0] == "expiration") {
-      std::time_t expiration = 0;
-      auto first = tag[1].data();
-      auto last = first + tag[1].size();
-      auto [ptr, ec] = std::from_chars(first, last, expiration);
-      if (ec == std::errc() && ptr == last && expiration <= now) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 static std::string make_placeholders(size_t n, int &pno) {
   std::string placeholders;
   for (size_t i = 0; i < n; ++i) {
@@ -295,7 +279,7 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
         if (ej["tags"].is_array() && ej["tags"].size() > 0) {
           std::vector<std::vector<std::string>> tags;
           ej["tags"].get_to(tags);
-          if (is_expired(tags)) {
+          if (has_expired_tags(tags, std::time(nullptr))) {
             continue;
           }
         }

--- a/sqlite3.cxx
+++ b/sqlite3.cxx
@@ -102,22 +102,6 @@ static bool insert_record(const event_t &ev) {
   return true;
 }
 
-static bool is_expired(std::vector<std::vector<std::string>> &tags) {
-  time_t now = time(nullptr);
-  for (const auto &tag : tags) {
-    if (tag.size() == 2 && tag[0] == "expiration") {
-      std::time_t expiration = 0;
-      auto first = tag[1].data();
-      auto last = first + tag[1].size();
-      auto [ptr, ec] = std::from_chars(first, last, expiration);
-      if (ec == std::errc() && ptr == last && expiration <= now) {
-        return true;
-      }
-    }
-  }
-  return false;
-}
-
 static bool send_records(std::function<void(const nlohmann::json &)> sender,
                          const std::string &sub,
                          const std::vector<filter_t> &filters, bool do_count,
@@ -282,7 +266,7 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
         if (ej["tags"].is_array() && ej["tags"].size() > 0) {
           std::vector<std::vector<std::string>> tags;
           ej["tags"].get_to(tags);
-          if (is_expired(tags)) {
+          if (has_expired_tags(tags, std::time(nullptr))) {
             continue;
           }
         }

--- a/test.cxx
+++ b/test.cxx
@@ -569,6 +569,19 @@ static void test_parse_a_coordinate() {
       "parse_a_coordinate rejects an empty value");
 }
 
+static void test_expiration_tags() {
+  _ok(!has_expired_tags({}, 100), "missing expiration is allowed");
+  _ok(!has_expired_tags({{"expiration"}}, 100), "missing expiration value is ignored");
+  _ok(has_expired_tags({{"expiration", "99"}}, 100), "past expiration is expired");
+  _ok(has_expired_tags({{"expiration", "100"}}, 100), "expiration boundary is expired");
+  _ok(!has_expired_tags({{"expiration", "101"}}, 100), "future expiration is allowed");
+  _ok(has_expired_tags({{"expiration", "99", "metadata"}}, 100), "extra fields do not hide expiration");
+  _ok(!has_expired_tags({{"expiration", "99junk"}}, 100), "partial timestamps are ignored");
+  _ok(!has_expired_tags({{"expiration", "9999999999999999999999999"}}, 100), "overflow does not wrap to expired");
+  _ok(has_expired_tags({{"expiration", "junk"}, {"expiration", "99"}}, 100), "malformed tag does not hide a valid expiration");
+  _ok(!has_expired_tags({{"expiration", "4102444800"}}, 100), "64-bit expiration is preserved");
+}
+
 static void test_created_at_within_limits() {
   std::time_t now = 1700000000;
 
@@ -611,6 +624,7 @@ int main() {
   subtest("test_cagliostr_delegation", test_cagliostr_delegation);
   subtest("test_count_leading_zero_bits", test_count_leading_zero_bits);
   subtest("test_parse_a_coordinate", test_parse_a_coordinate);
+  subtest("test_expiration_tags", test_expiration_tags);
   subtest("test_created_at_within_limits", test_created_at_within_limits);
   subtest("test_sql_injection_protection", test_sql_injection_protection);
   return done_testing();


### PR DESCRIPTION
Reject expired publications before storage or live delivery while preserving the ephemeral-event exemption. Share expiration parsing with stored queries and add boundary and malformed-tag regression tests.
