### PR TITLE
Preserve explicit zero timestamp filters

### DIFF
--- a/cagliostr.hxx
+++ b/cagliostr.hxx
@@ -28,8 +28,8 @@ using filter_t = struct filter_t {
   std::vector<std::string> authors{};
   std::vector<int> kinds{};
   std::vector<std::vector<std::string>> tags{};
-  std::time_t since{};
-  std::time_t until{};
+  std::optional<std::time_t> since;
+  std::optional<std::time_t> until;
   int limit{500};
   std::string search;
 };

--- a/main.cxx
+++ b/main.cxx
@@ -504,13 +504,13 @@ static bool matched_filters(const std::vector<filter_t> &filters,
         continue;
       }
     }
-    if (filter.since > 0) {
-      if (filter.since > ev.created_at) {
+    if (filter.since.has_value()) {
+      if (*filter.since > ev.created_at) {
         continue;
       }
     }
-    if (filter.until > 0) {
-      if (ev.created_at > filter.until) {
+    if (filter.until.has_value()) {
+      if (ev.created_at > *filter.until) {
         continue;
       }
     }

--- a/postgresql.cxx
+++ b/postgresql.cxx
@@ -220,14 +220,14 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
           "EXISTS (SELECT 1 FROM jsonb_array_elements(event.tags) AS tag "
           "WHERE tag->>0 = " + key + " AND tag->>1 IN (" + values + "))");
     }
-    if (filter.since != 0) {
+    if (filter.since.has_value()) {
       std::ostringstream os;
-      os << filter.since;
+      os << *filter.since;
       conditions.push_back("created_at >= " + os.str());
     }
-    if (filter.until != 0) {
+    if (filter.until.has_value()) {
       std::ostringstream os;
-      os << filter.until;
+      os << *filter.until;
       conditions.push_back("created_at <= " + os.str());
     }
     if (filter.limit >= 0 && filter.limit < limit) {

--- a/sqlite3.cxx
+++ b/sqlite3.cxx
@@ -185,14 +185,14 @@ static bool send_records(std::function<void(const nlohmann::json &)> sender,
           "WHERE json_extract(tag.value, '$[0]') = ? "
           "AND json_extract(tag.value, '$[1]') IN (" + join(values, ",") + "))");
     }
-    if (filter.since != 0) {
+    if (filter.since.has_value()) {
       std::ostringstream os;
-      os << filter.since;
+      os << *filter.since;
       conditions.push_back("created_at >= " + os.str());
     }
-    if (filter.until != 0) {
+    if (filter.until.has_value()) {
       std::ostringstream os;
-      os << filter.until;
+      os << *filter.until;
       conditions.push_back("created_at <= " + os.str());
     }
     if (filter.limit >= 0 && filter.limit < limit) {

--- a/test.cxx
+++ b/test.cxx
@@ -374,6 +374,29 @@ static void test_overlapping_filters() {
   storage_ctx.deinit();
 }
 
+static void test_zero_time_filters() {
+  auto storage_ctx = init_test_storage();
+  for (int timestamp : {-1, 0, 1}) {
+    _ok(storage_ctx.insert_record(make_event("epoch-" + std::to_string(timestamp),
+                                             "owner", timestamp, 1, {}, "")), "insert epoch fixture");
+  }
+  auto query = [&](filter_t filter, std::vector<int> expected) {
+    std::vector<int> timestamps;
+    _ok(storage_ctx.send_records([&](const nlohmann::json& r) { timestamps.push_back(r[2]["created_at"]); },
+                                 "epoch", {filter}, false, nullptr), "query epoch boundary");
+    _ok(timestamps == expected, "explicit epoch boundary is not an absent filter");
+  };
+  filter_t filter;
+  filter.until = 0;
+  query(filter, {0, -1});
+  filter = filter_t{};
+  filter.since = 0;
+  query(filter, {1, 0});
+  filter.until = 0;
+  query(filter, {0});
+  storage_ctx.deinit();
+}
+
 static void test_tag_filter_matching() {
   auto storage_ctx = init_test_storage();
   std::vector<event_t> events = {
@@ -650,6 +673,7 @@ int main() {
   if (!std::getenv("CAGLIOSTR_TEST_POSTGRES_DSN"))
     subtest("test_sqlite_event_roundtrip", test_sqlite_event_roundtrip);
   subtest("test_overlapping_filters", test_overlapping_filters);
+  subtest("test_zero_time_filters", test_zero_time_filters);
   subtest("test_tag_filter_matching", test_tag_filter_matching);
   subtest("test_send_records_filters", test_send_records_filters);
   subtest("test_delete_record_by_id_and_kind_and_ptag",


### PR DESCRIPTION
Distinguish absent time bounds from explicit zero timestamps in stored queries and live matching. Add epoch-boundary regression tests for both databases.
